### PR TITLE
make fill module inputs more permissive

### DIFF
--- a/jtlibrary/python/jtmodules/src/jtmodules/fill.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/fill.handles.yaml
@@ -1,10 +1,10 @@
 ---
-version: 0.0.1
+version: 0.0.2
 
 input:
 
     - name: mask
-      type: BinaryImage
+      type: MaskImage
       key:
       help: >
         Mask with holes in connected pixel components that

--- a/jtlibrary/python/jtmodules/src/jtmodules/fill.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/fill.py
@@ -19,7 +19,7 @@ import mahotas as mh
 
 logger = logging.getLogger(__name__)
 
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 Output = collections.namedtuple('Output', ['filled_mask', 'figure'])
 


### PR DESCRIPTION
`MaskImage` is the parent class for `BinaryImage` and `LabelImage`. This change therefore allows users to also filter label image inputs. A `BinaryImage` is still returned. This works because `mahotas.close_holes` actually converts to binary anyway here: https://github.com/luispedro/mahotas/blob/385f15c0a089d44d731bb5d906f23f0cbd8154e4/mahotas/morph.py#L494