### PR TITLE
Updates to input of threshold manual

### DIFF
--- a/jtlibrary/python/jtmodules/src/jtmodules/threshold_manual.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/threshold_manual.handles.yaml
@@ -1,10 +1,10 @@
 ---
-version: 0.0.1
+version: 0.0.2
 
 input:
 
     - name: image
-      type: Image
+      type: IntensityImage
       key:
       help: Image that should be thresholded.
 

--- a/jtlibrary/python/jtmodules/src/jtmodules/threshold_manual.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/threshold_manual.py
@@ -22,7 +22,7 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 Output = collections.namedtuple('Output', ['mask', 'figure'])
 


### PR DESCRIPTION
Currently a channel image cannot be directly thresholded (without first being processed) by another image. This fixes that.