### PR TITLE
Improve SVC UI: Make button clickable in correct states

### DIFF
--- a/tmui/src/app/src/tools/Classification/ClassificationTemplate.html
+++ b/tmui/src/app/src/tools/Classification/ClassificationTemplate.html
@@ -48,7 +48,7 @@
 
   <p>
     <button class="btn btn-primary"
-      ng-disabled="featureWidget.selectedFeatures.length == 0"
-      ng-click="toolCtrl.doClassify()">Classify</button>
+      ng-disabled="((featureWidget.selectedFeatures.length) == 0 && (toolCtrl.runClassifier)) || ((! toolCtrl.runClassifier) && (! toolCtrl.save_labels))"
+      ng-click="toolCtrl.doClassify()">Run</button>
   </p>
 </div>


### PR DESCRIPTION
This fix makes the UI button in the TissueMaps interface clickable in the correct state. Before, one could click the button when both the `Run Classifier` checkbox & the `Save Selection Labels` checkbox were unticked (and then nothing would happen). Also, it required the user to select some features even if they just wanted to run `Save Selection Labels`. Both those things are fixed with this change.

I also renamed the button to something more generic, as it doesn't always run a classification anymore.

Originally, this was also intended to allow for saving labels on Sites (which don't have features) instead of just the segmented mapobjects. Another issue came up there though: When downloading sites, it assigns the results to the wrong columns. Sites don't actually have tpoint, zplane, label & is_border values, but it still creates columns for them and then starts filling in the columns, thus assigning the first saved labels to tpoint, the second to zplane and so on.

This bug is out of scope for this UI fix, but good to be aware of. There doesn't seem to be issue tacking on the pelkmanslab TissueMaps github repository. Should we be able to create those @bebosudo ? Or should we post issues to TissueMaps/TissueMaps main repository?