### PR TITLE
Small module fixes & default adjustments

### DIFF
--- a/jtlibrary/python/jtmodules/src/jtmodules/filter.handles.yaml
+++ b/jtlibrary/python/jtmodules/src/jtmodules/filter.handles.yaml
@@ -41,10 +41,10 @@ input:
 
 output:
 
-    - name: filtered_mask
-      type: MaskImage
-      key: filter.filtered_mask
-      help: Filtered mask image.
+    - name: filtered_label_image
+      type: LabelImage
+      key: filter.filtered_label_image
+      help: Filtered image.
 
     - name: figure
       type: Figure

--- a/jtlibrary/python/jtmodules/src/jtmodules/filter.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/filter.py
@@ -25,7 +25,7 @@ VERSION = '0.2.0'
 
 logger = logging.getLogger(__name__)
 
-Output = collections.namedtuple('Output', ['filtered_mask', 'figure'])
+Output = collections.namedtuple('Output', ['filtered_label_image', 'figure'])
 
 SUPPORTED_FEATURES = {'area', 'eccentricity', 'circularity', 'convexity'}
 
@@ -74,7 +74,12 @@ def main(mask, feature, lower_threshold=None, upper_threshold=None, plot=False):
 
     name = 'Morphology_{0}'.format(feature.capitalize())
 
-    labeled_image = mh.label(mask > 0)[0]
+    # Only label image is it's a mask, avoid threshold based relabeling 
+    # for label images
+    if len(np.unique(mask)) < 3:
+        labeled_image = mh.label(mask > 0)[0]
+    else:
+        labeled_image = mask
     f = Morphology(labeled_image)
     measurement = f.extract()[name]
     values = measurement.values
@@ -93,23 +98,23 @@ def main(mask, feature, lower_threshold=None, upper_threshold=None, plot=False):
         condition_image = np.logical_or(
             feature_image < lower_threshold, feature_image > upper_threshold
         )
-        filtered_mask = labeled_image.copy()
-        filtered_mask[condition_image] = 0
+        filtered_label_image = labeled_image.copy()
+        filtered_label_image[condition_image] = 0
     else:
         logger.warn('no objects detected in image')
-        filtered_mask = labeled_image
+        filtered_label_image = labeled_image
 
-    mh.labeled.relabel(filtered_mask, inplace=True)
+    mh.labeled.relabel(filtered_label_image, inplace=True)
 
     if plot:
         from jtlib import plotting
         plots = [
             plotting.create_mask_image_plot(mask, 'ul'),
             plotting.create_float_image_plot(feature_image, 'ur'),
-            plotting.create_mask_image_plot(filtered_mask, 'll'),
+            plotting.create_mask_image_plot(filtered_label_image, 'll'),
         ]
         n_removed = (
-            len(np.unique(labeled_image)) - len(np.unique(filtered_mask))
+            len(np.unique(labeled_image)) - len(np.unique(filtered_label_image))
         )
         figure = plotting.create_figure(
             plots,
@@ -120,4 +125,4 @@ def main(mask, feature, lower_threshold=None, upper_threshold=None, plot=False):
     else:
         figure = str()
 
-    return Output(filtered_mask, figure)
+    return Output(filtered_label_image, figure)

--- a/jtlibrary/python/jtmodules/src/jtmodules/filter.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/filter.py
@@ -74,7 +74,7 @@ def main(mask, feature, lower_threshold=None, upper_threshold=None, plot=False):
 
     name = 'Morphology_{0}'.format(feature.capitalize())
 
-    # Only label image is it's a mask, avoid threshold based relabeling 
+    # Only label image if it's a mask, avoid threshold based relabeling 
     # for label images
     if len(np.unique(mask)) < 3:
         labeled_image = mh.label(mask > 0)[0]

--- a/jtlibrary/python/jtmodules/src/jtmodules/use_label_image.py
+++ b/jtlibrary/python/jtmodules/src/jtmodules/use_label_image.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 '''Jterator module for measuring intensity statistics.'''
 import collections
+import numpy as np
 
 VERSION = '0.1.0'
 
@@ -40,4 +41,4 @@ def main(input_image, plot=False):
     -------
     jtmodules.label.Output[Union[numpy.ndarray, str]]
     '''
-    return Output(input_image)
+    return Output(input_image.astype(np.int32))

--- a/tmlibrary/tmlib/workflow/align/args.py
+++ b/tmlibrary/tmlib/workflow/align/args.py
@@ -46,7 +46,7 @@ class AlignBatchArguments(BatchArguments):
     )
 
     robust_align = Argument(
-        type=bool, default=False, short_flag='r',
+        type=bool, default=True, short_flag='r',
         help='''whether pixel intensities are clipped to the specified percentile 
              to avoid artefacts (dirt may be small but have a high intensity. 
              Clipping its value stops it from distorting the alignment)'''


### PR DESCRIPTION
This pull request contains 3 small fixes:
1. The filter module is actually producing label images, but it pretended that they were MaskImages so far. I changed those settings and adapted the name of the relevant variables to avoid confusion
2. The use_label_image module had a bug with returning the image that is fixed by casting the image explicitly
3. I changed the default for alignment to use robust alignment. This basically just means that a percentile clipped image is used during alignment, avoiding artifacts from hot pixels & dirt